### PR TITLE
fix: dont compile on none windows, no warnings

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -9,10 +9,14 @@
           'cflags': [
             '/EHa',
           ],
+          "sources": ["src/module.cc"],
+          'msvs_settings': {
+            'VCCLCompilerTool': {
+              'ExceptionHandling': '1',    
+              'AdditionalOptions': ['/EHsc']
+            }
+          }
         },],
-      ],
-      "sources": [
-        "src/module.cc"
       ]
     }
   ]

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
   "name": "exe-icon-extractor",
-  "version": "1.0.6",
+  "version": "1.0.9",
   "lockfileVersion": 1
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "exe-icon-extractor",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "description": "Fork of @initthink/exe-icon-extractor",
   "main": "bindings.js",
   "scripts": {

--- a/src/module.cc
+++ b/src/module.cc
@@ -327,7 +327,7 @@ napi_value extractIcon(napi_env env, napi_callback_info info) {
 
 		return result;
 	}
-	catch(napi_status status){
+	catch(napi_status){
 		return 0;
 	}
 	catch(...) {


### PR DESCRIPTION
If referenced in x-plat projects compilation fails. this little tweak makes sure that compilation is only attempted on Windows. Alos got rid of compiler warnings. 